### PR TITLE
Add post type names for display

### DIFF
--- a/includes/core/content.php
+++ b/includes/core/content.php
@@ -1131,6 +1131,12 @@ class CCS_Content {
 				$result = apply_filters( 'the_title', $post->post_title ); break;
 			case 'slug': $result = $post->post_name; break;
 			case 'post-type': $result = $post->post_type; break;
+			case 'post-type-name': $post_type = $post->post_type; 
+                             $obj = get_post_type_object( $post_type );
+                             $result = $obj->labels->singular_name; break;
+      		case 'post-type-plural': $post_type = $post->post_type; 
+                             $obj = get_post_type_object( $post_type );
+                             $result = $obj->labels->name; break;
 
 			case 'title-link':
 			case 'title-link-out':


### PR DESCRIPTION
Case for post-type result is the slug. 
New case for post-type-name and post-type-plural results. 
These are good for uses like archive titles and labels on search results.
