### PR TITLE
allow passing user fields that are arrays or objects

### DIFF
--- a/includes/modules/pass.php
+++ b/includes/modules/pass.php
@@ -491,8 +491,14 @@ class CCS_Pass {
         foreach ($fields as $this_field) {
           $tag = '{'.$prefix.strtoupper($this_field).'}';
           $value = '';
-          if (isset($GLOBALS[$global][$this_field])) {
-            $value = $GLOBALS[$global][$this_field];
+          if (is_array($GLOBALS[$global])) {
+              if (isset($GLOBALS[$global][$this_field])) {
+                $value = $GLOBALS[$global][$this_field];
+              }
+          } elseif ( is_object($GLOBALS[$global]) ) {
+              if (isset($GLOBALS[$global]->$this_field)) {
+                $value = $GLOBALS[$global]->$this_field;
+              }
           }
           $content = str_replace($tag, $value, $content);
         }


### PR DESCRIPTION
current code assumes passed user variables are accessed as array values ... this detects whether the user field is an array or object and accesses the item properly and avoids a fatal error when it's an object