### PR TITLE
Add 2nd arg to get_the_excerpt filter

### DIFF
--- a/includes/core/content.php
+++ b/includes/core/content.php
@@ -1885,7 +1885,7 @@ class CCS_Content {
         $parts = explode('<!--more-->', $result);
         $result = isset($parts[0]) ? $parts[0] : '';
 
-        $result = apply_filters('get_the_excerpt', $result);
+        $result = apply_filters( 'get_the_excerpt', $result, $post );
 
       break;
 


### PR DESCRIPTION
Fixes fatal errors with ANY plugin that correctly uses get_the_excerpt filter with two args.
Fixes #8